### PR TITLE
Refactor Terraform variable definitions and improve formatting in VPC and subnet resources

### DIFF
--- a/frontend/terraform/variables.tf
+++ b/frontend/terraform/variables.tf
@@ -1,20 +1,26 @@
 variable vpc_cidr {}
 variable aws_region {}
 
-variable "public_subnet_cidr" {
-    type = list(string)
-    description = "Public subnet CIDR values"
-    default = ["10.0.10.0/24", "10.0.20.0/24"]
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  description = "CIDR blocks for public subnets"
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
 }
 
 variable "private_subnet_cidrs" {
-    type = list(string)
-    description = "Prvivate Subnet CIDR values"
-    default = [ "10.0.40.0/24", "10.0.50.0/24"]
+  type        = list(string)
+  description = "CIDR blocks for private subnets"
+  default     = ["10.0.3.0/24", "10.0.4.0/24"]
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "CIDR block for VPC"
+  default     = "10.0.0.0/16"
 }
 
 variable "azs" {
-    type = list(string)
-    description = "Availablility Zones"
-    default = [ "us-east-1a", "us-east-1b","us-east-1c"]
+  type        = list(string)
+  description = "Availability zones"
+  default     = ["us-west-2a", "us-west-2b"]
 }

--- a/frontend/terraform/vpc.tf
+++ b/frontend/terraform/vpc.tf
@@ -1,37 +1,41 @@
 # Virtual private cloud
 resource "aws_vpc" "myapp-vpc" {
-    cidr_block = var.vpc_cidr
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
 
-    tags = {
-      Name = "Project VPC"
-    }
+  tags = {
+    Name = "Project VPC"
+  }
 }
 
 
 # Public subnet
 resource "aws_subnet" "public_subnets" {
-  count = length(var.public_subnet_cidrs)
-  vpc_id = aws_vpc.myapp-vpc.id
-  cidr_block = element(var.public_subnet_cidrs, count.index)
-  availability_zone = element(var.azs, count.index)
+  count                   = length(var.public_subnet_cidrs)
+  vpc_id                  = aws_vpc.myapp-vpc.id
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  availability_zone       = var.azs[count.index]
   map_public_ip_on_launch = true
 
   tags = {
-    Name: "my-three-tier-app-public-subnet  ${count.index + 1}"
+    Name = "my-three-tier-app-public-subnet-${count.index + 1}"
+    Type = "Public"
   }
 }
 
+
 # private subnet
 resource "aws_subnet" "private_subnets" {
-  count = length(var.private_subnet_cidrs)
-  vpc_id = aws_vpc.myapp-vpc.id
-  cidr_block = element(var.private_subnet_cidrs, count.index)
+  count             = length(var.private_subnet_cidrs)
+  vpc_id            = aws_vpc.myapp-vpc.id
+  cidr_block        = element(var.private_subnet_cidrs, count.index)
   availability_zone = element(var.azs, count.index)
 
   tags = {
-    Name: "my-three-tier-app-private-subnet-${count.index + 1}"
+    Name : "my-three-tier-app-private-subnet-${count.index + 1}"
   }
-  
+
 }
 
 # Internet Gateway
@@ -44,7 +48,7 @@ resource "aws_internet_gateway" "igw" {
 }
 
 # Route Table for public subnet
-resource "aws_route_table" "public-rtb"{
+resource "aws_route_table" "public-rtb" {
   vpc_id = aws_vpc.myapp-vpc.id
   route {
     cidr_block = "0.0.0.0/0"
@@ -55,11 +59,11 @@ resource "aws_route_table" "public-rtb"{
     Name = "public-rtb"
   }
 }
-  
+
 # Associating the public subnet with the route table that has IGW
 resource "aws_route_table_association" "public-subnet-association" {
-  count = length(var.public_subnet_cidrs)
-  subnet_id = element(aws_subnet.public_subnets[*].id, count.index)
+  count          = length(var.public_subnet_cidrs)
+  subnet_id      = element(aws_subnet.public_subnets[*].id, count.index)
   route_table_id = aws_route_table.public-rtb.id
 }
 
@@ -74,9 +78,9 @@ resource "aws_eip" "nat" {
 
 #  NAT Gateway in Public Subnet 1
 resource "aws_nat_gateway" "nat" {
-  count = 1
+  count         = 1
   allocation_id = aws_eip.nat.id
-  subnet_id  = element(aws_subnet.public_subnets[*].id, count.index)
+  subnet_id     = element(aws_subnet.public_subnets[*].id, count.index)
   tags = {
     Name = "main-nat-${count.index + 1}"
   }
@@ -86,10 +90,10 @@ resource "aws_nat_gateway" "nat" {
 
 # Private Route Table
 resource "aws_route_table" "private-rtb" {
-  count = length(aws_nat_gateway.nat)
+  count  = length(aws_nat_gateway.nat)
   vpc_id = aws_vpc.myapp-vpc.id
-  route  {
-    cidr_block = "0.0.0.0/0"
+  route {
+    cidr_block     = "0.0.0.0/0"
     nat_gateway_id = element(aws_nat_gateway.nat[*].id, count.index)
   }
 
@@ -100,7 +104,7 @@ resource "aws_route_table" "private-rtb" {
 
 # Private Route Table Associations
 resource "aws_route_table_association" "private-subnet-association" {
-  count = length(var.private_subnet_cidrs)
-  subnet_id = element(aws_subnet.private_subnets[*].id, count.index)
+  count          = length(var.private_subnet_cidrs)
+  subnet_id      = element(aws_subnet.private_subnets[*].id, count.index)
   route_table_id = element(aws_route_table.private-rtb[*].id, count.index)
 }


### PR DESCRIPTION
This pull request updates the Terraform configuration for the frontend infrastructure to enhance clarity, consistency, and functionality. Key changes include renaming and modifying variable definitions, updating default values, and improving resource configurations for better DNS support and tagging.

### Variable updates:
* [`frontend/terraform/variables.tf`](diffhunk://#diff-21b362e6455f0bd9d6b8b4ccfff31f01bbe190a682df587f010f747ed1a69bd1L4-R25): Renamed `public_subnet_cidr` to `public_subnet_cidrs` and updated its description and default values. Similarly, updated descriptions and default values for `private_subnet_cidrs`, `vpc_cidr`, and `azs` variables for improved clarity and accuracy.

### Resource configuration improvements:
* [`frontend/terraform/vpc.tf`](diffhunk://#diff-237706dcaedb391f74e2a9d97a2704609b6d6dde0d9f7f2e87e47227d648951dR4-R5): Enabled DNS hostnames and DNS support in the `aws_vpc` resource for better functionality.
* [`frontend/terraform/vpc.tf`](diffhunk://#diff-237706dcaedb391f74e2a9d97a2704609b6d6dde0d9f7f2e87e47227d648951dL15-R27): Refactored the `aws_subnet` resource for public subnets to use direct indexing (`var.public_subnet_cidrs[count.index]` and `var.azs[count.index]`) instead of `element()` for better readability. Added a `Type` tag to distinguish subnet types.